### PR TITLE
Support optional VCAP_SERVICES binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ The fastest way to deploy this application to Bluemix is to click the Deploy to 
 
 [![Deploy to Bluemix](https://deployment-tracker.mybluemix.net/stats/aa7ed2e962f16e8eee0b5ee0ab5f31fb/button.svg)](https://bluemix.net/deploy?repository=https://github.com/ibm-watson-data-lab/advo-beta-dashboard)
 
+
+[![Deploy to Bluemix](https://deployment-tracker.mybluemix.net/stats/aa7ed2e962f16e8eee0b5ee0ab5f31fb/button.svg)](https://bluemix.net/deploy?repository=https://github.com/ptitzler/advo-beta-dashboard)
+
 **Don't have a Bluemix account?** If you haven't already, you'll be prompted to sign up for a Bluemix account when you click the button.  Sign up, verify your email address, then return here and click the the **Deploy to Bluemix** button again. Your new credentials let you deploy to the platform and also to code online with Bluemix and Git. If you have questions about working in Bluemix, find answers in the [Bluemix Docs](https://www.ng.bluemix.net/docs/).
 
 Or you could manually deploy from the command-line.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ The fastest way to deploy this application to Bluemix is to click the Deploy to 
 
 [![Deploy to Bluemix](https://deployment-tracker.mybluemix.net/stats/aa7ed2e962f16e8eee0b5ee0ab5f31fb/button.svg)](https://bluemix.net/deploy?repository=https://github.com/ibm-watson-data-lab/advo-beta-dashboard)
 
-
-[![Deploy to Bluemix](https://deployment-tracker.mybluemix.net/stats/aa7ed2e962f16e8eee0b5ee0ab5f31fb/button.svg)](https://bluemix.net/deploy?repository=https://github.com/ptitzler/advo-beta-dashboard)
-
 **Don't have a Bluemix account?** If you haven't already, you'll be prompted to sign up for a Bluemix account when you click the button.  Sign up, verify your email address, then return here and click the the **Deploy to Bluemix** button again. Your new credentials let you deploy to the platform and also to code online with Bluemix and Git. If you have questions about working in Bluemix, find answers in the [Bluemix Docs](https://www.ng.bluemix.net/docs/).
 
 Or you could manually deploy from the command-line.

--- a/index.js
+++ b/index.js
@@ -41,11 +41,13 @@ var generateLatestReport  = function(callback) {
   ], function(err, results) {
     if (!err) {
       var funnel = results[0];
-      latestReport.funnel.users = parseInt(funnel.login_count);
-      latestReport.funnel.baskets = parseInt(funnel.basket_count);
-      latestReport.funnel.orders = parseInt(funnel.checkout_count);
-      latestReport.lastHour.sumItems = parseInt(funnel.basket_total);
-      latestReport.lastHour.sumOrders = parseInt(funnel.checkout_total);
+      if(funnel) {
+        latestReport.funnel.users = parseInt(funnel.login_count);
+        latestReport.funnel.baskets = parseInt(funnel.basket_count);
+        latestReport.funnel.orders = parseInt(funnel.checkout_count);
+        latestReport.lastHour.sumItems = parseInt(funnel.basket_total);
+        latestReport.lastHour.sumOrders = parseInt(funnel.checkout_total);
+      }
     }
     callback(null, latestReport);
   });

--- a/index.js
+++ b/index.js
@@ -4,7 +4,19 @@ var server = require('http').createServer(app);
 var io = require('socket.io')(server);
 var redis = require('redis');
 var async = require('async');
+
+// get cloudfoundry config
+var cfenv = require('cfenv'),
+  appEnv = cfenv.getAppEnv();
+
+console.log(JSON.stringify(appEnv));
+
 var redis_url = process.env.REDIS_URL || 'redis://localhost:6379';
+var redisSvc = appEnv.getService('redis-service');
+if((redisSvc) && (redisSvc.hasOwnProperty('credentials')) && redisSvc.credentials.hasOwnProperty('uri')) {
+  redis_url = redisSvc.credentials.uri;
+} 
+
 var redisClient = redis.createClient(redis_url);
 
 // template report
@@ -54,10 +66,6 @@ setInterval(function() {
   });
 }, 1000);
 
-
-// get cloudfoundry config
-var cfenv = require('cfenv'),
-  appEnv = cfenv.getAppEnv();
 
 // listen
 server.listen(appEnv.port, '0.0.0.0', function () {

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,3 +1,8 @@
+---
+declared-services:
+  redis-service:
+    label: compose-for-redis
+    plan: Standard
 applications:
 - name: dashboard
   path: .
@@ -8,3 +13,5 @@ applications:
   domain: mybluemix.net
   random-route: true
   command: node index.js
+  services:
+  - redis-service

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "advo-beta-dashboard",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Application now supports binding of a Redis service through environment variable `VCAP_SERVICES`, if a service named `redis-service` is associated.
* Bind priority: `VCAP_SERVICES` > `REDIS_URL` > default (localhost).
* Bug fix for NullPointerException if Redis repository wasn't initialized