### PR TITLE
support rediscloud

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,2 +1,2 @@
-start.sh
 node_modules
+.gitignore

--- a/index.js
+++ b/index.js
@@ -22,11 +22,22 @@ console.log(JSON.stringify(appEnv));
 var redis_url = process.env.REDIS_URL;
 if (!redis_url) {
   // Custom REDIS_URL is not defined. If a Redis service instance is bound to this app use it.
-  if((appEnv.hasOwnProperty('services')) && (appEnv.services.hasOwnProperty('compose-for-redis')) && (appEnv.services['compose-for-redis'].length > 0)) {
-    var redisSvc = appEnv.services['compose-for-redis'][0];
-    if((redisSvc.hasOwnProperty('credentials')) && redisSvc.credentials.hasOwnProperty('uri')) {
-      redis_url = redisSvc.credentials.uri;
-    } 
+  if(appEnv.hasOwnProperty('services')) {
+    // check if a Compose for Redis service instance is bound to this app
+    if ((appEnv.services.hasOwnProperty('compose-for-redis')) && (appEnv.services['compose-for-redis'].length > 0)) { 
+      var redisSvc = appEnv.services['compose-for-redis'][0];
+      if((redisSvc.hasOwnProperty('credentials')) && redisSvc.credentials.hasOwnProperty('uri')) {
+        redis_url = redisSvc.credentials.uri;
+      } 
+    }
+    // check if a RedisCloud service instance is bound to this app
+    else if ((appEnv.services.hasOwnProperty('rediscloud')) && (appEnv.services['rediscloud'].length > 0)) { 
+      var redisSvc = appEnv.services['rediscloud'][0];
+      if((redisSvc.hasOwnProperty('credentials')) && redisSvc.credentials.hasOwnProperty('hostname') && 
+          redisSvc.credentials.hasOwnProperty('password') && redisSvc.credentials.hasOwnProperty('port')) {
+        redis_url = 'redis://x:' + redisSvc.credentials['password'] + '@' + redisSvc.credentials['hostname'] + ':' + redisSvc.credentials['port'];
+      } 
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "advo-beta-dashboard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added opinionated support for _RedisCloud_ service:
* The "Deploy to IBM Cloud" button lists _Compose for Redis_ as service dependency.
* If _Compose for Redis_ and _RedisCloud_ service instances are bound to the app, _Compose for Redis_ will be used as data store.